### PR TITLE
[DONE] Fix/grey color for Miro palette

### DIFF
--- a/frontend/src/chat/components/Chat/Message.svelte
+++ b/frontend/src/chat/components/Chat/Message.svelte
@@ -43,7 +43,7 @@
     	.message__timestamp {
         	margin: 0 5px;
         	padding-top: 10px;
-      	color: #bbb;
+      	color: #827F9B;
 	}
 
     	.message__timestamp.hidden {


### PR DESCRIPTION
# Description

Use exact color from SDK docs for timestamps next to messages (only visible when hovering message).